### PR TITLE
Add type checks for CliAgent

### DIFF
--- a/gpt_engineer/applications/cli/cli_agent.py
+++ b/gpt_engineer/applications/cli/cli_agent.py
@@ -139,6 +139,11 @@ class CliAgent(BaseAgent):
         CliAgent
             An instance of CliAgent configured with the provided or default parameters.
         """
+        if not isinstance(memory, DiskMemory):
+            raise TypeError("memory must be an instance of DiskMemory")
+        if not isinstance(execution_env, DiskExecutionEnv):
+            raise TypeError("execution_env must be an instance of DiskExecutionEnv")
+
         return cls(
             memory=memory,
             execution_env=execution_env,

--- a/tests/applications/cli/test_cli_agent.py
+++ b/tests/applications/cli/test_cli_agent.py
@@ -150,5 +150,12 @@ def test_improve_standard_config(monkeypatch):
     assert code[outfile] == "!dlroW olleH"
 
 
+def test_with_default_config_validates_types(tmp_path):
+    with pytest.raises(TypeError):
+        CliAgent.with_default_config("foo", DiskExecutionEnv())
+    with pytest.raises(TypeError):
+        CliAgent.with_default_config(DiskMemory(tmp_path), "bar")
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
## Summary
- add explicit type validation for `CliAgent.with_default_config`
- cover invalid parameters in tests

## Testing
- `pre-commit run --files gpt_engineer/applications/cli/cli_agent.py tests/applications/cli/test_cli_agent.py` *(fails: command not found)*
- `pytest -q tests/applications/cli/test_cli_agent.py` *(fails: command not found)*