### PR TITLE
Add GUI run command with project_path argument

### DIFF
--- a/gpt_engineer/applications/gui/main.py
+++ b/gpt_engineer/applications/gui/main.py
@@ -1,0 +1,19 @@
+"""GUI entry point for GPT Engineer."""
+
+from pathlib import Path
+
+import typer
+
+from gpt_engineer.applications.cli import main as cli_main
+
+app = typer.Typer()
+
+
+@app.command()
+def run(project_path: Path = typer.Argument(..., help="Directory to store generated files")):
+    """Run the GUI and save project files in ``project_path``."""
+    cli_main.main(str(project_path))
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Summary
- add new `gpt_engineer.applications.gui` package
- expose a `run` CLI command that accepts a project path argument
- delegate execution to the existing CLI entrypoint

## Testing
- `pytest -k 'not test_installation' -q` *(fails: `pytest` not found)*