### PR TITLE
Add advanced Flask GUI option

### DIFF
--- a/docs/gui.md
+++ b/docs/gui.md
@@ -1,13 +1,14 @@
 Using the GUI
 =============
 
-gpt-engineer ships with a lightweight graphical interface built with ``tkinter``. It provides a simple window for editing your prompt, choosing the model and running code generation.
+gpt-engineer ships with two graphical interfaces. The basic one is built with ``tkinter`` and provides a simple window for editing your prompt and running code generation. A more powerful web-based interface built with ``Flask`` exposes additional controls.
 
 Launch
 ------
 
 1. Create your project folder and add a ``prompt`` file just like when using the CLI.
-2. Run ``gpte <project_dir> --gui``.
+2. Run ``gpte <project_dir> --gui`` for the Tk interface or ``gpte <project_dir> --advanced-gui`` to start the web UI.
+   Use ``--advanced-gui-host`` and ``--advanced-gui-port`` to change the address.
 3. A window opens where you can adjust settings and start the generation process.
 
 Generated code will appear in ``<project_dir>/workspace`` as usual.
@@ -19,3 +20,9 @@ Capabilities
 - Toggle improve mode or standard generation.
 - Set model name and temperature.
 - Start and stop the run from the interface while monitoring logs.
+
+Advanced GUI
+------------
+
+The advanced web interface adds controls for model selection, temperature, microservice generation and self-healing. A help panel explains each option and logs update in real time while the agent runs.
+The Run button is automatically disabled while generation is in progress and a status indicator shows when the agent is busy.

--- a/gpt_engineer/applications/cli/main.py
+++ b/gpt_engineer/applications/cli/main.py
@@ -42,6 +42,7 @@ from termcolor import colored
 from gpt_engineer.applications.cli.cli_agent import CliAgent
 from gpt_engineer.applications.cli.collect import collect_and_send_human_review
 from gpt_engineer.applications.cli.file_selector import FileSelector
+from gpt_engineer.applications.gui.advanced_gui import run as run_advanced_gui
 from gpt_engineer.applications.gui.main import run as run_gui
 from gpt_engineer.core.ai import AI, ClipboardAI
 from gpt_engineer.core.default.disk_execution_env import DiskExecutionEnv
@@ -296,6 +297,21 @@ def main(
         "-g",
         help="Launch the graphical interface instead of running in the console.",
     ),
+    advanced_gui: bool = typer.Option(
+        False,
+        "--advanced-gui",
+        help="Launch the advanced web interface instead of running in the console.",
+    ),
+    advanced_gui_host: str = typer.Option(
+        "127.0.0.1",
+        "--advanced-gui-host",
+        help="Host for the advanced GUI.",
+    ),
+    advanced_gui_port: int = typer.Option(
+        5000,
+        "--advanced-gui-port",
+        help="Port for the advanced GUI.",
+    ),
     prompt_file: str = typer.Option(
         "prompt",
         "--prompt_file",
@@ -340,6 +356,7 @@ def main(
 ):
     if debug:
         import pdb
+
         sys.excepthook = lambda *_: pdb.pm()
 
     if sysinfo:
@@ -350,6 +367,10 @@ def main(
 
     if gui:
         run_gui(project_path)
+        raise typer.Exit()
+
+    if advanced_gui:
+        run_advanced_gui(project_path, host=advanced_gui_host, port=advanced_gui_port)
         raise typer.Exit()
 
     if improve_mode and (clarify_mode or lite_mode):
@@ -390,6 +411,7 @@ def main(
         from gpt_engineer.applications.service_generator.api_automator import (
             generate_microservice,
         )
+
         generate_microservice(path, prompt.text)
         print(f"Microservice files created in {path}")
         return

--- a/gpt_engineer/applications/gui/advanced_gui.py
+++ b/gpt_engineer/applications/gui/advanced_gui.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+# ruff: noqa: E402
+
+"""A simple Flask-based GUI exposing advanced options."""
+
+from pathlib import Path
+from threading import Thread
+from typing import List
+
+try:
+    from flask import Flask, jsonify, render_template_string, request
+except Exception:  # pragma: no cover - optional dependency
+    Flask = None  # type: ignore
+
+from gpt_engineer.applications.cli.cli_agent import CliAgent
+from gpt_engineer.core.default.disk_execution_env import DiskExecutionEnv
+from gpt_engineer.core.default.disk_memory import DiskMemory
+from gpt_engineer.core.default.file_store import FileStore
+from gpt_engineer.core.default.paths import memory_path
+from gpt_engineer.core.prompt import Prompt
+
+HELP_TEXT = """\
+* **Model**: Which language model to use for generation.
+* **Temperature**: Controls randomness of the model output.
+* **Generate Microservice**: Creates a Flask microservice from your prompt.
+* **Self Heal**: Attempts to automatically repair generated code.
+"""
+
+TEMPLATE = """
+<!doctype html>
+<title>GPT Engineer Advanced GUI</title>
+<h1>GPT Engineer Advanced GUI</h1>
+<form method='post'>
+  <textarea name='prompt' rows='10' cols='60' placeholder='Enter prompt here'></textarea><br>
+  Model: <input name='model'><br>
+  Temperature: <input type='number' step='0.1' name='temperature' value='0.1'><br>
+  <label><input type='checkbox' name='microservice'>Generate Microservice</label><br>
+  <label><input type='checkbox' name='self_heal'>Enable Self Heal</label><br>
+  <input id='run-button' type='submit' value='Run'>
+</form>
+<div>Status: <span id='status'>Idle</span></div>
+<h2>Help</h2>
+<pre>{{ help_text }}</pre>
+<h2>Logs</h2>
+<pre id='logs'></pre>
+<script>
+function fetchLogs() {
+  fetch('/logs').then(r => r.json()).then(d => {
+    document.getElementById('logs').textContent = d.logs.join('\n');
+  });
+}
+function fetchStatus() {
+  fetch('/status').then(r => r.json()).then(d => {
+    document.getElementById('run-button').disabled = d.running;
+    document.getElementById('status').textContent = d.running ? 'Running' : 'Idle';
+  });
+}
+setInterval(() => { fetchLogs(); fetchStatus(); }, 1000);
+fetchLogs();
+fetchStatus();
+</script>
+"""
+
+
+class AdvancedGUI:
+    """Encapsulates the Flask application and agent."""
+
+    def __init__(self, project_path: Path) -> None:
+        if Flask is None:
+            raise RuntimeError("Flask is required for the advanced GUI")
+        self.project_path = Path(project_path)
+        self.memory = DiskMemory(memory_path(self.project_path))
+        self.execution_env = DiskExecutionEnv()
+        self.store = FileStore(self.project_path)
+        self.agent = CliAgent.with_default_config(self.memory, self.execution_env)
+        self.logs: List[str] = []
+        self.running = False
+        self.agent.set_update_callback(self._log)
+        self.app = Flask(__name__)
+        self._setup_routes()
+
+    def _log(self, message: str) -> None:
+        self.logs.append(message)
+
+    def _setup_routes(self) -> None:
+        app = self.app
+
+        @app.route("/", methods=["GET", "POST"])
+        def index():
+            if request.method == "POST":
+                prompt_text = request.form.get("prompt", "")
+                model = request.form.get("model")
+                temperature = request.form.get("temperature", "0")
+                microservice = request.form.get("microservice") is not None
+                self_heal = request.form.get("self_heal") is not None
+                self.logs.clear()
+                self.running = True
+
+                def task():
+                    if model:
+                        self.agent.config.model = model
+                    if temperature:
+                        try:
+                            self.agent.config.temperature = float(temperature)
+                        except ValueError:
+                            pass
+                    self.agent.self_heal_mode = self_heal
+                    self.agent.microservice = microservice
+                    try:
+                        files = self.agent.init(Prompt(prompt_text))
+                        self.store.push(files)
+                    finally:
+                        self.running = False
+
+                Thread(target=task, daemon=True).start()
+            return render_template_string(TEMPLATE, help_text=HELP_TEXT)
+
+        @app.route("/logs")
+        def logs():
+            return jsonify(logs=self.logs)
+
+        @app.route("/status")
+        def status():
+            return jsonify(running=self.running)
+
+    def run(self, host: str = "127.0.0.1", port: int = 5000) -> None:
+        self.app.run(host=host, port=port)
+
+
+def create_app(project_path: Path | str = "projects/example") -> Flask:
+    gui = AdvancedGUI(Path(project_path))
+    return gui.app
+
+
+def run(
+    project_path: str = "projects/example", host: str = "127.0.0.1", port: int = 5000
+) -> None:
+    AdvancedGUI(Path(project_path)).run(host=host, port=port)

--- a/tests/applications/gui/test_advanced_gui.py
+++ b/tests/applications/gui/test_advanced_gui.py
@@ -1,0 +1,21 @@
+import pytest
+
+try:
+    from flask import Flask
+
+    from gpt_engineer.applications.gui.advanced_gui import create_app
+except Exception:
+    Flask = None
+    create_app = None
+
+
+def test_create_app(tmp_path):
+    if Flask is None or create_app is None:  # pragma: no cover - dependency missing
+        pytest.skip("Flask not available")
+    p = tmp_path / "projects/example"
+    p.mkdir(parents=True)
+    (p / "prompt").write_text("hi")
+    app = create_app(p)
+    assert isinstance(app, Flask)
+    routes = {rule.endpoint for rule in app.url_map.iter_rules()}
+    assert "status" in routes


### PR DESCRIPTION
## Summary
- add new `advanced_gui.py` Flask interface
- expose `--advanced-gui` flag in CLI
- document advanced web UI
- test GUI creation when Flask is available
- allow host/port options and show run status in the UI

## Testing
- `ruff check --fix gpt_engineer/applications/gui/advanced_gui.py gpt_engineer/applications/cli/main.py tests/applications/gui/test_advanced_gui.py`
- `black gpt_engineer/applications/gui/advanced_gui.py gpt_engineer/applications/cli/main.py tests/applications/gui/test_advanced_gui.py`
- `pytest -q` *(fails: command not found)*
- `pip install pytest` *(fails: No route to host)*