### PR TITLE
Add smol swarm parallel execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Check the [Windows README](./WINDOWS_README.md) for Windows usage.
 - Create a folder with a `prompt` describing the API
 - Run `gpte <project_dir> --microservice`
 - The command writes a `Dockerfile`, `app.py` and `requirements.txt` into the directory
+
+### Run a smol swarm
+
+- Define micro steps separated by semicolons: `--swarm-steps "setup env;write tests;implement"`
+- Run `gpte <project_dir> --smol-swarm --swarm-steps "setup env;write tests;implement"`
+- Each step is executed by a separate agent in parallel and results are merged
 - 
 ### Benchmark custom agents
 - gpt-engineer installs the binary 'bench', which gives you a simple interface for benchmarking your own agent implementations against popular public datasets.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -78,6 +78,13 @@ Generate a Microservice
 - Run ``gpte <project_dir> --microservice``
 - ``gpt-engineer`` will create ``app.py`` and ``Dockerfile`` in the folder
 
+Run a Smol Swarm
+----------------
+
+- Define micro-steps separated by semicolons using ``--swarm-steps``
+- ``gpte <project_dir> --smol-swarm --swarm-steps "setup env;write tests;implement"``
+- Tasks are executed by multiple agents in parallel and merged automatically
+
 
 By running ``gpt-engineer`` you agree to our `terms <./terms_link.html>`_.
 

--- a/gpt_engineer/agent_swarms/__init__.py
+++ b/gpt_engineer/agent_swarms/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for running groups of SimpleAgents in parallel."""
+
+from .swarm_controller import run_task_swarm
+
+__all__ = ["run_task_swarm"]

--- a/gpt_engineer/agent_swarms/swarm_controller.py
+++ b/gpt_engineer/agent_swarms/swarm_controller.py
@@ -1,0 +1,40 @@
+"""Controller for running multiple SimpleAgent instances concurrently."""
+import tempfile
+import threading
+from typing import List
+
+from gpt_engineer.core.default.simple_agent import SimpleAgent
+from gpt_engineer.core.files_dict import FilesDict
+from gpt_engineer.core.prompt import Prompt
+
+
+def run_task_swarm(prompt: Prompt, steps: List[str]) -> FilesDict:
+    """Run micro-steps of a task concurrently using multiple SimpleAgents.
+
+    Each step text is appended to the base ``prompt`` and executed in a
+    separate ``SimpleAgent``. The resulting ``FilesDict`` objects are merged and
+    returned.
+    """
+
+    results: List[FilesDict] = []
+    results_lock = threading.Lock()
+
+    def _run(step: str) -> None:
+        agent = SimpleAgent.with_default_config(tempfile.mkdtemp())
+        step_prompt = Prompt(prompt.text + "\n" + step,
+                             prompt.image_urls,
+                             entrypoint_prompt=prompt.entrypoint_prompt)
+        files = agent.init(step_prompt)
+        with results_lock:
+            results.append(files)
+
+    threads = [threading.Thread(target=_run, args=(s,)) for s in steps]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    merged: FilesDict = FilesDict()
+    for files in results:
+        merged.update(files)
+    return merged

--- a/gpt_engineer/applications/cli/cli_agent.py
+++ b/gpt_engineer/applications/cli/cli_agent.py
@@ -11,6 +11,7 @@ from gpt_engineer.core.ai import AI
 from gpt_engineer.core.base_agent import BaseAgent
 from gpt_engineer.core.base_execution_env import BaseExecutionEnv
 from gpt_engineer.core.base_memory import BaseMemory
+from gpt_engineer.agent_swarms import run_task_swarm
 from gpt_engineer.core.default.disk_execution_env import DiskExecutionEnv
 from gpt_engineer.core.default.disk_memory import DiskMemory
 from gpt_engineer.core.default.paths import PREPROMPTS_PATH
@@ -182,4 +183,11 @@ class CliAgent(BaseAgent):
             diff_timeout=diff_timeout,
         )
         self._send_update("improve_end")
+        return files_dict
+
+    def run_swarm(self, prompt: Prompt, steps: List[str]) -> FilesDict:
+        """Execute a task using a swarm of ``SimpleAgent`` instances."""
+        self._send_update("swarm_start")
+        files_dict = run_task_swarm(prompt, steps)
+        self._send_update("swarm_end")
         return files_dict

--- a/gpt_engineer/applications/cli/main.py
+++ b/gpt_engineer/applications/cli/main.py
@@ -261,6 +261,16 @@ def main(
         "-sh",
         help="Self-heal mode - fix the code by itself when it fails.",
     ),
+    smol_swarm: bool = typer.Option(
+        False,
+        "--smol-swarm",
+        help="Use a swarm of SimpleAgents to execute micro-steps in parallel.",
+    ),
+    swarm_steps: str = typer.Option(
+        "",
+        "--swarm-steps",
+        help="Semicolon separated list of steps for the smol swarm.",
+    ),
     microservice: bool = typer.Option(
         False,
         "--microservice",
@@ -450,7 +460,11 @@ def main(
                 if not prompt_yesno():
                     files_dict = files_dict_before
         else:
-            files_dict = agent.init(prompt)
+            if smol_swarm:
+                steps = [s.strip() for s in swarm_steps.split(";") if s.strip()]
+                files_dict = agent.run_swarm(prompt, steps)
+            else:
+                files_dict = agent.init(prompt)
             config = (code_gen_fn.__name__, execution_fn.__name__)
             collect_and_send_human_review(prompt, model, temperature, config, memory)
 

--- a/tests/agent_swarms/test_swarm.py
+++ b/tests/agent_swarms/test_swarm.py
@@ -1,0 +1,26 @@
+import time
+
+from gpt_engineer.agent_swarms import swarm_controller
+from gpt_engineer.core.files_dict import FilesDict
+from gpt_engineer.core.prompt import Prompt
+
+
+class DummyAgent:
+    @classmethod
+    def with_default_config(cls, *_args, **_kwargs):
+        return cls()
+
+    def init(self, prompt: Prompt) -> FilesDict:
+        time.sleep(0.2)
+        key = prompt.text.strip()
+        return FilesDict({key: "done"})
+
+
+def test_run_task_swarm_parallel(monkeypatch):
+    monkeypatch.setattr(swarm_controller, "SimpleAgent", DummyAgent)
+    start = time.perf_counter()
+    result = swarm_controller.run_task_swarm(Prompt("task"), ["step1", "step2"])
+    duration = time.perf_counter() - start
+    assert duration < 0.35
+    assert result == {"task\nstep1": "done", "task\nstep2": "done"}
+


### PR DESCRIPTION
## Summary
- implement a new `agent_swarms` package with `run_task_swarm`
- extend `CliAgent` and CLI main to optionally run a swarm via `--smol-swarm`
- document swarm usage in README and Quickstart docs
- add basic unit test for swarm parallelism

## Testing
- `pytest -q` *(fails: pytest not installed)*